### PR TITLE
feat(projects): replace isDone boolean with status enum

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,7 +164,7 @@ The wrapper is `inline-flex items-center gap-1.5`.
 | Medium | `text-warning` |
 | Low | `text-base-content/40` |
 
-**Projects reuse this same indicator pattern.** Project Status is `Done` (`CheckCircle2Icon text-success`) vs `Active` (`CircleIcon text-base-content/50`); Favorite is a filled `StarIcon text-warning` vs muted `text-base-content/30`. Progress is the one exception to the icon+label rule: a muted `completed/total` count beside a thin track-and-fill bar (`bg-success` only at 100%), never a badge.
+**Projects reuse this same indicator pattern.** Project Status is an enum that shares the task vocabulary — `In Progress` (`TimerIcon text-warning`) vs `Done` (`CheckCircle2Icon text-success`); Favorite is a filled `StarIcon text-warning` vs muted `text-base-content/30`. Progress is the one exception to the icon+label rule: a muted `completed/total` count beside a thin track-and-fill bar (`bg-success` only at 100%), never a badge.
 
 ---
 
@@ -172,13 +172,15 @@ The wrapper is `inline-flex items-center gap-1.5`.
 
 **Task rows and project rows** share the same pattern: a Radix `DropdownMenu` triggered by an ellipsis icon button (`dsy-btn dsy-btn-ghost dsy-btn-square dsy-btn-sm`) via `DropdownMenu.Trigger asChild`. The popup (`DropdownMenu.Content`, rendered in a `DropdownMenu.Portal`) uses DaisyUI's `dsy-menu` class with `rounded-box bg-base-100 shadow-sm`. Items activate via `onSelect`; navigation items use `DropdownMenu.Item asChild` wrapping a router `Link`. Quick-edit submenus (task Status/Priority/Label) use `DropdownMenu.Sub`/`SubTrigger`/`SubContent`. Destructive items (Delete) carry `text-error`. Edit/Rename and Delete items open dedicated Radix dialogs by setting local `useState` booleans (the dialogs are rendered with `withTrigger={false}` and driven by the menu).
 
-For project rows, the boolean fields shown as read-only indicator columns (Status, Favorite) are toggled from this same menu (Favorite/Unfavorite, Mark as done/not done) — there are no inline row buttons or toggles.
+For project rows, the indicator columns are edited from this same menu — Status via a `DropdownMenu.Sub` submenu (In Progress/Done, mirroring the task Status submenu) and Favorite via a Favorite/Unfavorite item. There are no inline row buttons or toggles.
 
 ---
 
 ## Boolean Toggles
 
-Boolean project fields (Favorite, Done) use `dsy-toggle dsy-toggle-sm` checkboxes rather than buttons or icons. The Favorite toggle uses `dsy-toggle-warning`; the Done toggle uses `dsy-toggle-success`. Each toggle is paired with a descriptive icon visible alongside it, and the semantic label is provided via `sr-only` text for screen readers.
+Favorite is the only boolean project field, rendered as a `dsy-toggle dsy-toggle-sm dsy-toggle-warning` checkbox rather than a button or icon. The toggle is paired with a descriptive icon visible alongside it, and the semantic label is provided via `sr-only` text for screen readers.
+
+Project Status is an enum (not a boolean), so it is never a toggle: it is edited via the floating-label shared `Select` in the edit dialog, the row-action Status submenu, and a compact inline `dsy-select dsy-select-sm` in the project-detail header.
 
 ---
 

--- a/backend/src/routes/metadata.ts
+++ b/backend/src/routes/metadata.ts
@@ -1,8 +1,14 @@
 import { Elysia, t } from "elysia";
 
 import { authPlugin } from "../middleware/auth";
+import { selectProjectSchema } from "../models/projects";
 import { selectTaskSchema } from "../models/tasks";
-import { labels, priorities, statuses } from "../schemas/constants";
+import {
+  labels,
+  priorities,
+  projectStatuses,
+  statuses,
+} from "../schemas/constants";
 
 const tags = ["Metadata"];
 
@@ -10,12 +16,13 @@ const MetadataSchema = t.Object({
   statuses: t.Array(t.Index(selectTaskSchema, ["status"])),
   priorities: t.Array(t.Index(selectTaskSchema, ["priority"])),
   labels: t.Array(t.Index(selectTaskSchema, ["label"])),
+  projectStatuses: t.Array(t.Index(selectProjectSchema, ["status"])),
 });
 
 export const metadataRoutes = new Elysia({ prefix: "/metadata" })
   .use(authPlugin)
   .model({ Metadata: MetadataSchema })
-  .get("", () => ({ statuses, priorities, labels }), {
+  .get("", () => ({ statuses, priorities, labels, projectStatuses }), {
     auth: true,
     response: "Metadata",
     detail: { tags, summary: "Get Metadata" },

--- a/backend/src/routes/projects.$projectId.ts
+++ b/backend/src/routes/projects.$projectId.ts
@@ -57,7 +57,7 @@ export const projectRoutes = new Elysia({ prefix: "/:projectId" })
           "description",
           "isFavorite",
           "name",
-          "isDone",
+          "status",
         ]),
       ),
       response: "Project",

--- a/backend/src/schemas/constants.ts
+++ b/backend/src/schemas/constants.ts
@@ -6,6 +6,11 @@ export const statuses = [
   "Canceled" as const,
 ] satisfies [string, ...string[]];
 
+export const projectStatuses = [
+  "In Progress" as const,
+  "Done" as const,
+] satisfies [string, ...string[]];
+
 export const priorities = [
   "Low" as const,
   "Medium" as const,

--- a/backend/src/schemas/projects.ts
+++ b/backend/src/schemas/projects.ts
@@ -2,7 +2,7 @@ import { relations } from "drizzle-orm";
 import { sqliteTable } from "drizzle-orm/sqlite-core";
 
 import { nanoid, now } from "../utils";
-import { labels, priorities, statuses } from "./constants";
+import { labels, priorities, projectStatuses, statuses } from "./constants";
 import { users } from "./users";
 
 export const projects = sqliteTable("project", (t) => ({
@@ -10,7 +10,7 @@ export const projects = sqliteTable("project", (t) => ({
   name: t.text().unique().notNull(),
   description: t.text().notNull(),
   isFavorite: t.integer({ mode: "boolean" }).default(false).notNull(),
-  isDone: t.integer({ mode: "boolean" }).default(false).notNull(),
+  status: t.text({ enum: projectStatuses }).default("In Progress").notNull(),
   createdAt: t.text().$default(now).notNull(),
   updatedAt: t.text().$default(now).$onUpdate(now).notNull(),
   userId: t

--- a/frontend/src/components/edit-project.spec.tsx
+++ b/frontend/src/components/edit-project.spec.tsx
@@ -10,6 +10,14 @@ describe("<EditProject />", () => {
       http.get("/projects/1", () => {
         return HttpResponse.json({});
       }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
+      }),
     ];
 
     server.use(...handlers);
@@ -27,6 +35,14 @@ describe("<EditProject />", () => {
     const handlers = [
       http.get("/projects/1", () => {
         return HttpResponse.json({});
+      }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
       }),
     ];
 
@@ -48,6 +64,14 @@ describe("<EditProject />", () => {
     const handlers = [
       http.get("/projects/1", () => {
         return HttpResponse.json({});
+      }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
       }),
     ];
 

--- a/frontend/src/components/edit-project.tsx
+++ b/frontend/src/components/edit-project.tsx
@@ -4,7 +4,9 @@ import { Dialog } from "radix-ui";
 import { useState } from "react";
 
 import { editProjectOptions } from "@/api/edit-project";
+import { queryMetadataOptions } from "@/api/query-metadata";
 import { projectQueryOptions } from "@/api/query-project";
+import { Select } from "@/components/shared/select";
 import { TextInput } from "@/components/shared/text-input";
 import { useEditProjectForm } from "@/hooks/forms/edit-project";
 import { cn } from "@/utils/cn";
@@ -27,6 +29,7 @@ export const EditProject = ({
   withTrigger = true,
 }: EditProjectProps) => {
   const { data: project } = useSuspenseQuery(projectQueryOptions(projectId));
+  const { data: metadata } = useSuspenseQuery(queryMetadataOptions());
   const { mutate } = useMutation(editProjectOptions);
   const [internalOpen, setInternalOpen] = useState(false);
 
@@ -76,42 +79,32 @@ export const EditProject = ({
                 })}
               >
                 <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-4">
-                    <TextInput
-                      control={form.control}
-                      name="name"
-                      label="Name"
-                      className="w-full"
+                  <TextInput
+                    control={form.control}
+                    name="name"
+                    label="Name"
+                    className="w-full"
+                  />
+                  <TextInput
+                    control={form.control}
+                    name="description"
+                    label="Description"
+                  />
+                  <Select control={form.control} name="status" label="Status">
+                    {metadata.projectStatuses.map((status) => (
+                      <option key={status} value={status}>
+                        {status}
+                      </option>
+                    ))}
+                  </Select>
+                  <label className="flex cursor-pointer items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="dsy-toggle dsy-toggle-warning"
+                      {...form.register("isFavorite")}
                     />
-                    <TextInput
-                      control={form.control}
-                      name="description"
-                      label="Description"
-                    />
-                  </div>
-                  <fieldset className="dsy-fieldset">
-                    <legend className="dsy-fieldset-legend">
-                      Project Options
-                    </legend>
-                    <div className="flex gap-4">
-                      <label className="flex cursor-pointer items-center gap-2">
-                        <input
-                          type="checkbox"
-                          className="dsy-toggle"
-                          {...form.register("isFavorite")}
-                        />
-                        Favorite
-                      </label>
-                      <label className="flex cursor-pointer items-center gap-2">
-                        <input
-                          type="checkbox"
-                          className="dsy-toggle"
-                          {...form.register("isDone")}
-                        />
-                        Done
-                      </label>
-                    </div>
-                  </fieldset>
+                    Favorite
+                  </label>
                 </div>
                 <div className="flex justify-end gap-2">
                   <button

--- a/frontend/src/components/project-actions.spec.tsx
+++ b/frontend/src/components/project-actions.spec.tsx
@@ -13,10 +13,18 @@ describe("<ProjectActions />", () => {
           name: "Revamp Testing Suite",
           description: "",
           isFavorite: false,
-          isDone: false,
+          status: "In Progress",
           createdAt: "2024-08-25T16:54:05.991Z",
           updatedAt: "2024-08-25T16:54:05.991Z",
           userId: "1",
+        });
+      }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
         });
       }),
     ];
@@ -28,8 +36,7 @@ describe("<ProjectActions />", () => {
       initialEntries: ["/(authenticated)/projects/1"],
     });
 
-    const checkboxes = screen.getAllByRole("checkbox");
-
-    expect(checkboxes).toHaveLength(2);
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project-actions.tsx
+++ b/frontend/src/components/project-actions.tsx
@@ -1,8 +1,9 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
-import { FolderCheckIcon, StarIcon } from "lucide-react";
+import { StarIcon } from "lucide-react";
 
 import { editProjectOptions } from "@/api/edit-project";
+import { queryMetadataOptions } from "@/api/query-metadata";
 import { projectQueryOptions } from "@/api/query-project";
 
 const routeApi = getRouteApi("/(authenticated)/projects/$projectId");
@@ -10,6 +11,7 @@ const routeApi = getRouteApi("/(authenticated)/projects/$projectId");
 export const ProjectActions = () => {
   const { projectId } = routeApi.useParams();
   const { data: project } = useSuspenseQuery(projectQueryOptions(projectId));
+  const { data: metadata } = useSuspenseQuery(queryMetadataOptions());
   const { mutate: editProject } = useMutation(editProjectOptions);
 
   return (
@@ -31,19 +33,23 @@ export const ProjectActions = () => {
       </label>
 
       <label className="flex cursor-pointer items-center gap-1.5 text-sm">
-        <input
-          type="checkbox"
-          className="dsy-toggle dsy-toggle-sm dsy-toggle-success"
-          checked={project.isDone}
+        <span className="sr-only">Status</span>
+        <select
+          className="dsy-select dsy-select-sm"
+          value={project.status}
           onChange={(e) =>
             editProject({
               params: { projectId },
-              body: { isDone: e.target.checked },
+              body: { status: e.target.value as typeof project.status },
             })
           }
-        />
-        <FolderCheckIcon className="h-3.5 w-3.5" />
-        <span className="sr-only">Done</span>
+        >
+          {metadata.projectStatuses.map((status) => (
+            <option key={status} value={status}>
+              {status}
+            </option>
+          ))}
+        </select>
       </label>
     </div>
   );

--- a/frontend/src/components/project-details.spec.tsx
+++ b/frontend/src/components/project-details.spec.tsx
@@ -8,7 +8,12 @@ describe("<ProjectDetails />", () => {
   it("should render", async () => {
     const handlers = [
       http.get("/metadata", () => {
-        return HttpResponse.json({ labels: [], priorities: [], statuses: [] });
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
       }),
       http.get("/projects/1", () => {
         return HttpResponse.json({
@@ -16,7 +21,7 @@ describe("<ProjectDetails />", () => {
           name: "Revamp Testing Suite",
           description: "",
           isFavorite: false,
-          isDone: false,
+          status: "In Progress",
           createdAt: "2024-08-25T16:54:05.991Z",
           updatedAt: "2024-08-25T16:54:05.991Z",
           userId: "1",

--- a/frontend/src/components/projects-menu-item.spec.tsx
+++ b/frontend/src/components/projects-menu-item.spec.tsx
@@ -4,7 +4,11 @@ import { ProjectsMenuItem } from "./projects-menu-item";
 describe("<ProjectsMenuItem />", () => {
   it("should render", async () => {
     await render(
-      <ProjectsMenuItem projectId="1" name="Revamp Testing Suite" isDone />,
+      <ProjectsMenuItem
+        projectId="1"
+        name="Revamp Testing Suite"
+        status="Done"
+      />,
     );
 
     const link = screen.getByRole("link", {
@@ -19,7 +23,7 @@ describe("<ProjectsMenuItem />", () => {
       <ProjectsMenuItem
         projectId="1"
         name="Revamp Testing Suite"
-        isDone={false}
+        status="In Progress"
       />,
     );
 

--- a/frontend/src/components/projects-menu-item.tsx
+++ b/frontend/src/components/projects-menu-item.tsx
@@ -4,13 +4,13 @@ import { FolderCheckIcon, FolderIcon } from "lucide-react";
 interface ProjectsMenuItemProps {
   projectId: string;
   name: string;
-  isDone: boolean;
+  status: "In Progress" | "Done";
 }
 
 export const ProjectsMenuItem = ({
   projectId,
   name,
-  isDone,
+  status,
 }: ProjectsMenuItemProps) => {
   return (
     <Link
@@ -18,7 +18,7 @@ export const ProjectsMenuItem = ({
       params={{ projectId }}
       activeProps={{ className: "dsy-active" }}
     >
-      {isDone ? (
+      {status === "Done" ? (
         <FolderCheckIcon className="h-4 w-4" aria-label="Project Done:" />
       ) : (
         <FolderIcon className="h-4 w-4" aria-label="Project Not Done:" />

--- a/frontend/src/components/projects-table/columns.spec.tsx
+++ b/frontend/src/components/projects-table/columns.spec.tsx
@@ -11,7 +11,7 @@ const baseProject = {
   name: "Revamp Testing Suite",
   description: "",
   isFavorite: false,
-  isDone: false,
+  status: "In Progress" as const,
   createdAt: "2024-08-25T16:54:05.991Z",
   updatedAt: "2024-08-25T16:54:05.991Z",
   userId: "1",
@@ -27,6 +27,14 @@ describe("columns", () => {
       http.get("/projects/:projectId", () => {
         return HttpResponse.json(baseProject);
       }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
+      }),
     );
 
     await render(
@@ -36,7 +44,7 @@ describe("columns", () => {
             ...baseProject,
             description: "has description",
             isFavorite: true,
-            isDone: true,
+            status: "Done" as const,
             taskSummary: { total: 4, completed: 4 },
           },
           {

--- a/frontend/src/components/projects-table/columns.tsx
+++ b/frontend/src/components/projects-table/columns.tsx
@@ -43,9 +43,9 @@ export const columns = [
       );
     },
   }),
-  columnHelper.accessor("isDone", {
+  columnHelper.accessor("status", {
     header: "Status",
-    cell: (info) => <ProjectStatusCell isDone={info.getValue()} />,
+    cell: (info) => <ProjectStatusCell status={info.getValue()} />,
   }),
   columnHelper.accessor(
     (row) =>

--- a/frontend/src/components/projects-table/project-actions.spec.tsx
+++ b/frontend/src/components/projects-table/project-actions.spec.tsx
@@ -10,7 +10,7 @@ const project = {
   name: "Revamp Testing Suite",
   description: "",
   isFavorite: false,
-  isDone: false,
+  status: "In Progress" as const,
   createdAt: "2024-08-25T16:54:05.991Z",
   updatedAt: "2024-08-25T16:54:05.991Z",
   userId: "1",
@@ -21,6 +21,14 @@ describe("<ProjectActions />", () => {
     server.use(
       http.get("/projects/:projectId", () => {
         return HttpResponse.json(project);
+      }),
+      http.get("/metadata", () => {
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: ["In Progress", "Done"],
+        });
       }),
     );
 

--- a/frontend/src/components/projects-table/project-actions.tsx
+++ b/frontend/src/components/projects-table/project-actions.tsx
@@ -1,7 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
-  CheckIcon,
   EllipsisIcon,
   EyeIcon,
   ListTodoIcon,
@@ -14,6 +13,7 @@ import { useState } from "react";
 
 import type { APIRoutes } from "@/api/client";
 import { editProjectOptions } from "@/api/edit-project";
+import { queryMetadataOptions } from "@/api/query-metadata";
 
 import { DeleteProject } from "../delete-project";
 import { EditProject } from "../edit-project";
@@ -23,6 +23,7 @@ interface ProjectActionsProps {
 }
 
 export const ProjectActions = ({ project }: ProjectActionsProps) => {
+  const { data } = useSuspenseQuery(queryMetadataOptions());
   const editMutation = useMutation(editProjectOptions);
 
   const [editOpen, setEditOpen] = useState(false);
@@ -64,18 +65,36 @@ export const ProjectActions = ({ project }: ProjectActionsProps) => {
               <StarIcon className="h-4 w-4" />
             </DropdownMenu.Item>
 
-            <DropdownMenu.Item
-              onSelect={() => {
-                editMutation.mutate({
-                  params: { projectId: project.id },
-                  body: { isDone: !project.isDone },
-                });
-              }}
-              className="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-sm outline-none hover:bg-base-200 data-highlighted:bg-base-200"
-            >
-              {project.isDone ? "Mark as not done" : "Mark as done"}
-              <CheckIcon className="h-4 w-4" />
-            </DropdownMenu.Item>
+            <DropdownMenu.Sub>
+              <DropdownMenu.SubTrigger className="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-sm outline-none hover:bg-base-200 data-highlighted:bg-base-200">
+                Status
+              </DropdownMenu.SubTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.SubContent
+                  alignOffset={-4}
+                  sideOffset={-4}
+                  className="dsy-menu z-1 w-52 rounded-box bg-base-100 p-2 shadow-sm"
+                >
+                  {data.projectStatuses.map((status) => (
+                    <DropdownMenu.Item
+                      key={status}
+                      onSelect={() => {
+                        editMutation.mutate({
+                          params: { projectId: project.id },
+                          body: { status },
+                        });
+                      }}
+                      className="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-sm outline-none hover:bg-base-200 data-highlighted:bg-base-200"
+                    >
+                      {status}
+                      {project.status === status && (
+                        <span className="dsy-badge dsy-badge-xs dsy-badge-info" />
+                      )}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Sub>
 
             <DropdownMenu.Separator className="dsy-divider my-1" />
 

--- a/frontend/src/components/projects-table/status-cell.spec.tsx
+++ b/frontend/src/components/projects-table/status-cell.spec.tsx
@@ -4,14 +4,14 @@ import { ProjectStatusCell } from "./status-cell";
 
 describe("<ProjectStatusCell />", () => {
   it("should render done", async () => {
-    await render(<ProjectStatusCell isDone />);
+    await render(<ProjectStatusCell status="Done" />);
 
     expect(screen.getByText("Done")).toBeInTheDocument();
   });
 
-  it("should render active", async () => {
-    await render(<ProjectStatusCell isDone={false} />);
+  it("should render in progress", async () => {
+    await render(<ProjectStatusCell status="In Progress" />);
 
-    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/projects-table/status-cell.tsx
+++ b/frontend/src/components/projects-table/status-cell.tsx
@@ -1,18 +1,21 @@
-import { CheckCircle2Icon, CircleIcon } from "lucide-react";
+import { CheckCircle2Icon, TimerIcon } from "lucide-react";
 
 import { ICON_CLASS } from "@/utils/cell-classes";
 
-export const ProjectStatusCell = ({ isDone }: { isDone: boolean }) => {
+const cellsByStatus = {
+  "In Progress": <TimerIcon className={`${ICON_CLASS} text-warning`} />,
+  Done: <CheckCircle2Icon className={`${ICON_CLASS} text-success`} />,
+};
+
+export const ProjectStatusCell = ({
+  status,
+}: {
+  status: keyof typeof cellsByStatus;
+}) => {
   return (
     <span className="inline-flex items-center gap-1.5">
-      {isDone ? (
-        <CheckCircle2Icon className={`${ICON_CLASS} text-success`} />
-      ) : (
-        <CircleIcon className={`${ICON_CLASS} text-base-content/50`} />
-      )}
-      <span className="hidden text-sm sm:inline">
-        {isDone ? "Done" : "Active"}
-      </span>
+      {cellsByStatus[status]}
+      <span className="hidden text-sm sm:inline">{status}</span>
     </span>
   );
 };

--- a/frontend/src/components/task-details.spec.tsx
+++ b/frontend/src/components/task-details.spec.tsx
@@ -10,7 +10,7 @@ const mockProject = {
   name: "Revamp Testing Suite",
   description: "",
   isFavorite: false,
-  isDone: false,
+  status: "In Progress",
   createdAt: "2024-08-25T16:54:05.991Z",
   updatedAt: "2024-08-25T16:54:05.991Z",
 };

--- a/frontend/src/components/tasks-table/task-actions.spec.tsx
+++ b/frontend/src/components/tasks-table/task-actions.spec.tsx
@@ -8,7 +8,12 @@ describe("<RowActions />", () => {
   it("should render", async () => {
     const handlers = [
       http.get("/metadata", () => {
-        return HttpResponse.json({ labels: [], priorities: [], statuses: [] });
+        return HttpResponse.json({
+          labels: [],
+          priorities: [],
+          statuses: [],
+          projectStatuses: [],
+        });
       }),
     ];
     server.use(...handlers);
@@ -28,7 +33,7 @@ describe("<RowActions />", () => {
             name: "Revamp Testing Suite",
             description: "",
             isFavorite: false,
-            isDone: false,
+            status: "In Progress",
             createdAt: "2024-08-25T16:54:05.991Z",
             updatedAt: "2024-08-25T16:54:05.991Z",
           },

--- a/frontend/src/hooks/forms/edit-project.ts
+++ b/frontend/src/hooks/forms/edit-project.ts
@@ -5,6 +5,7 @@ import {
   type InferOutput,
   nonEmpty,
   object,
+  picklist,
   pipe,
   string,
 } from "valibot";
@@ -13,7 +14,7 @@ const schema = object({
   name: pipe(string(), nonEmpty("Name is required.")),
   description: pipe(string(), nonEmpty("Description is required.")),
   isFavorite: boolean(),
-  isDone: boolean(),
+  status: picklist(["In Progress", "Done"]),
 });
 
 export const useEditProjectForm = (values: InferOutput<typeof schema>) => {


### PR DESCRIPTION
## Why

- Projects tracked completion with an `isDone` boolean while tasks already use a richer `status` enum. A boolean can only ever express two states, and modeling the same concept two different ways is inconsistent.
- The goal is a model that's **uniform** with tasks (shares the status vocabulary) and **scalable** to more states later, plus an edit UX that matches the design system rather than a one-off raw `<select>`.

## What

- **Backend:** replaced the `isDone` boolean column with a `status` text enum (`In Progress`, `Done`, default `In Progress`) in the Drizzle schema; the PATCH `/projects/:id` body now accepts `status`; `GET /metadata` exposes `projectStatuses` (mirroring task `statuses`).
- **Frontend:** types flow automatically via Eden Treaty. Status cell now uses the icon+label indicator map; the projects table column reads `status`; the row-actions menu swaps "Mark as done/not done" for a **Status submenu** (mirroring tasks).
- **Edit UX:** the edit dialog now uses the shared floating-label `Select` in a clean vertical stack (Name → Description → Status → Favorite), dropping the raw `<select>`/`fieldset`; the detail-header keeps a compact inline status control beside the Favorite toggle.
- **Tests:** updated all project mocks/assertions from `isDone` to `status` and added `/metadata` handlers where the new metadata query is triggered.
- **Docs:** DESIGN.md updated (Status indicators, Row Actions, Boolean Toggles) to reflect the status enum.

> [!NOTE]
> The project uses `drizzle-kit push` (no committed migrations). Applying this drops `is_done` and adds `status` defaulting to `In Progress`; existing rows with `is_done = true` won't auto-map to `Done`. Run `UPDATE project SET status = 'Done' WHERE is_done = 1;` before pushing if live data must be preserved.