### PR TITLE
feat(projects): ✨ split task rollup into dedicated /projects/stats

### DIFF
--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,4 +1,4 @@
-import { count, eq, getTableColumns, sql } from "drizzle-orm";
+import { count, desc, eq, sql } from "drizzle-orm";
 import { Elysia, InternalServerError, t } from "elysia";
 
 import { db } from "../db";
@@ -13,36 +13,27 @@ export const projectsRoutes = new Elysia({ prefix: "/projects" })
   .use(authPlugin)
   .model({
     Project: selectProjectSchema,
-    Projects: t.Array(
-      t.Composite([
-        selectProjectSchema,
-        t.Object({
-          taskSummary: t.Object({
-            total: t.Number(),
-            completed: t.Number(),
-          }),
-        }),
-      ]),
+    Projects: t.Array(selectProjectSchema),
+    ProjectStats: t.Array(
+      t.Object({
+        id: t.String(),
+        name: t.String(),
+        Backlog: t.Number(),
+        Todo: t.Number(),
+        "In Progress": t.Number(),
+        Done: t.Number(),
+        Canceled: t.Number(),
+      }),
     ),
   })
   .get(
     "",
     async ({ user }) => {
-      const rows = await db
-        .select({
-          ...getTableColumns(projects),
-          total: count(tasks.id),
-          completed: count(sql`case when ${tasks.status} = 'Done' then 1 end`),
-        })
+      return await db
+        .select()
         .from(projects)
-        .leftJoin(tasks, eq(tasks.projectId, projects.id))
         .where(eq(projects.userId, user.id))
-        .groupBy(projects.id);
-
-      return rows.map(({ total, completed, ...project }) => ({
-        ...project,
-        taskSummary: { total, completed },
-      }));
+        .orderBy(desc(projects.updatedAt));
     },
     {
       auth: true,
@@ -72,53 +63,32 @@ export const projectsRoutes = new Elysia({ prefix: "/projects" })
     },
   )
   .get(
-    "/totals",
+    "/stats",
     async ({ user }) => {
-      const projectsWithTasks = await db.query.projects.findMany({
-        where: eq(projects.userId, user.id),
-        orderBy: (tasks, { desc }) => desc(tasks.updatedAt),
-        columns: {
-          id: true,
-          name: true,
-        },
-        with: {
-          tasks: {
-            columns: {
-              status: true,
-            },
-          },
-        },
-      });
-
-      return projectsWithTasks.map(({ id, name, tasks }) => {
-        return {
-          id,
-          name,
-          ...tasks.reduce(
-            (acc, curr) => {
-              acc[curr.status] = acc[curr.status] + 1;
-
-              return acc;
-            },
-            { Backlog: 0, Todo: 0, "In Progress": 0, Done: 0, Canceled: 0 },
+      return await db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          Backlog: count(sql`case when ${tasks.status} = 'Backlog' then 1 end`),
+          Todo: count(sql`case when ${tasks.status} = 'Todo' then 1 end`),
+          "In Progress": count(
+            sql`case when ${tasks.status} = 'In Progress' then 1 end`,
           ),
-        };
-      });
+          Done: count(sql`case when ${tasks.status} = 'Done' then 1 end`),
+          Canceled: count(
+            sql`case when ${tasks.status} = 'Canceled' then 1 end`,
+          ),
+        })
+        .from(projects)
+        .leftJoin(tasks, eq(tasks.projectId, projects.id))
+        .where(eq(projects.userId, user.id))
+        .groupBy(projects.id)
+        .orderBy(desc(projects.updatedAt));
     },
     {
       auth: true,
-      response: t.Array(
-        t.Object({
-          id: t.String(),
-          name: t.String(),
-          Backlog: t.Number(),
-          Todo: t.Number(),
-          "In Progress": t.Number(),
-          Done: t.Number(),
-          Canceled: t.Number(),
-        }),
-      ),
-      detail: { tags, summary: "List Projects' Totals" },
+      response: "ProjectStats",
+      detail: { tags, summary: "List Project Stats" },
     },
   )
   .use(projectRoutes);

--- a/frontend/src/api/create-project.ts
+++ b/frontend/src/api/create-project.ts
@@ -2,6 +2,7 @@ import type { APIRoutes } from "@/api/client";
 import { api } from "@/api/client";
 import { mutationOptions } from "@/api/mutation-options";
 import { projectsQueryOptions } from "@/api/query-projects";
+import { projectStatsQueryOptions } from "@/api/query-projects-stats";
 import queryClient from "@/query-client";
 
 export const createProjectOptions = mutationOptions({
@@ -18,13 +19,22 @@ export const createProjectOptions = mutationOptions({
     await queryClient.cancelQueries(projectsQueryOptions);
   },
   onSuccess: (newProject) => {
-    const listItem = {
-      ...newProject,
-      taskSummary: { total: 0, completed: 0 },
+    queryClient.setQueryData(projectsQueryOptions.queryKey, (oldProjects) => {
+      return oldProjects ? [...oldProjects, newProject] : [newProject];
+    });
+
+    const statsItem = {
+      id: newProject.id,
+      name: newProject.name,
+      Backlog: 0,
+      Todo: 0,
+      "In Progress": 0,
+      Done: 0,
+      Canceled: 0,
     };
 
-    queryClient.setQueryData(projectsQueryOptions.queryKey, (oldProjects) => {
-      return oldProjects ? [...oldProjects, listItem] : [listItem];
+    queryClient.setQueryData(projectStatsQueryOptions.queryKey, (oldStats) => {
+      return oldStats ? [...oldStats, statsItem] : [statsItem];
     });
   },
 });

--- a/frontend/src/api/create-task.ts
+++ b/frontend/src/api/create-task.ts
@@ -3,6 +3,7 @@ import { api } from "@/api/client";
 import { mutationOptions } from "@/api/mutation-options";
 import queryClient from "@/query-client";
 
+import { projectStatsQueryOptions } from "./query-projects-stats";
 import { queryTasksOptions } from "./query-tasks";
 
 export const createTask = mutationOptions({
@@ -19,6 +20,9 @@ export const createTask = mutationOptions({
     await queryClient.cancelQueries(queryTasksOptions());
   },
   onSuccess: async () => {
-    await queryClient.invalidateQueries(queryTasksOptions());
+    await Promise.all([
+      queryClient.invalidateQueries(queryTasksOptions()),
+      queryClient.invalidateQueries(projectStatsQueryOptions),
+    ]);
   },
 });

--- a/frontend/src/api/delete-project.ts
+++ b/frontend/src/api/delete-project.ts
@@ -1,8 +1,8 @@
 import { api } from "@/api/client";
 import { mutationOptions } from "@/api/mutation-options";
 import queryClient from "@/query-client";
-
 import { projectsQueryOptions } from "./query-projects";
+import { projectStatsQueryOptions } from "./query-projects-stats";
 
 export const deleteProjectOptions = mutationOptions({
   meta: { globalError: true, errorMessage: "Couldn't delete project." },
@@ -21,6 +21,10 @@ export const deleteProjectOptions = mutationOptions({
   onSuccess: ({ id }) => {
     queryClient.setQueryData(projectsQueryOptions.queryKey, (oldProjects) => {
       return oldProjects?.filter((oldProject) => oldProject.id !== id);
+    });
+
+    queryClient.setQueryData(projectStatsQueryOptions.queryKey, (oldStats) => {
+      return oldStats?.filter((oldStat) => oldStat.id !== id);
     });
   },
 });

--- a/frontend/src/api/delete-task.ts
+++ b/frontend/src/api/delete-task.ts
@@ -2,6 +2,7 @@ import { api } from "@/api/client";
 import { mutationOptions } from "@/api/mutation-options";
 import queryClient from "@/query-client";
 
+import { projectStatsQueryOptions } from "./query-projects-stats";
 import { queryTasksOptions } from "./query-tasks";
 
 export const deleteTaskMutationOptions = mutationOptions({
@@ -16,6 +17,9 @@ export const deleteTaskMutationOptions = mutationOptions({
     return res.data;
   },
   onSuccess: async () => {
-    await queryClient.invalidateQueries(queryTasksOptions());
+    await Promise.all([
+      queryClient.invalidateQueries(queryTasksOptions()),
+      queryClient.invalidateQueries(projectStatsQueryOptions),
+    ]);
   },
 });

--- a/frontend/src/api/edit-project.ts
+++ b/frontend/src/api/edit-project.ts
@@ -4,6 +4,7 @@ import { mutationOptions } from "@/api/mutation-options";
 import queryClient from "@/query-client";
 import { projectQueryOptions } from "./query-project";
 import { projectsQueryOptions } from "./query-projects";
+import { projectStatsQueryOptions } from "./query-projects-stats";
 
 export const editProjectOptions = mutationOptions({
   meta: { globalError: true, errorMessage: "Couldn't update project." },
@@ -26,9 +27,15 @@ export const editProjectOptions = mutationOptions({
     );
     queryClient.setQueryData(projectsQueryOptions.queryKey, (oldProjects) => {
       return oldProjects?.map((project) =>
-        project.id === updatedProject.id
-          ? { ...updatedProject, taskSummary: project.taskSummary }
-          : project,
+        project.id === updatedProject.id ? updatedProject : project,
+      );
+    });
+
+    queryClient.setQueryData(projectStatsQueryOptions.queryKey, (oldStats) => {
+      return oldStats?.map((stat) =>
+        stat.id === updatedProject.id
+          ? { ...stat, name: updatedProject.name }
+          : stat,
       );
     });
   },

--- a/frontend/src/api/edit-task.tsx
+++ b/frontend/src/api/edit-task.tsx
@@ -3,6 +3,7 @@ import { api } from "@/api/client";
 import { mutationOptions } from "@/api/mutation-options";
 import queryClient from "@/query-client";
 
+import { projectStatsQueryOptions } from "./query-projects-stats";
 import { queryTasksOptions } from "./query-tasks";
 
 export const editTaskMutationOptions = mutationOptions({
@@ -20,6 +21,9 @@ export const editTaskMutationOptions = mutationOptions({
     return res.data;
   },
   onSuccess: async () => {
-    await queryClient.invalidateQueries(queryTasksOptions());
+    await Promise.all([
+      queryClient.invalidateQueries(queryTasksOptions()),
+      queryClient.invalidateQueries(projectStatsQueryOptions),
+    ]);
   },
 });

--- a/frontend/src/api/query-projects-stats.ts
+++ b/frontend/src/api/query-projects-stats.ts
@@ -2,10 +2,10 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api/client";
 
-export const projectsTotalsQueryOptions = queryOptions({
-  queryKey: ["projects", "totals"] as const,
+export const projectStatsQueryOptions = queryOptions({
+  queryKey: ["projects", "stats"] as const,
   queryFn: async () => {
-    const res = await api.projects.totals.get();
+    const res = await api.projects.stats.get();
 
     if (res.error) {
       throw res.error;

--- a/frontend/src/components/overview-chart.spec.tsx
+++ b/frontend/src/components/overview-chart.spec.tsx
@@ -8,7 +8,7 @@ import { OverviewChart } from "./overview-chart";
 describe("<OverviewChart />", () => {
   it("should render", async () => {
     const handlers = [
-      http.get("/projects/totals", () => {
+      http.get("/projects/stats", () => {
         return HttpResponse.json([
           {
             id: "1",

--- a/frontend/src/components/overview-chart.tsx
+++ b/frontend/src/components/overview-chart.tsx
@@ -8,10 +8,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { projectsTotalsQueryOptions } from "@/api/query-projects-totals";
+import { projectStatsQueryOptions } from "@/api/query-projects-stats";
 
 export const OverviewChart = () => {
-  const { data } = useSuspenseQuery(projectsTotalsQueryOptions);
+  const { data } = useSuspenseQuery(projectStatsQueryOptions);
 
   return (
     <ResponsiveContainer width="100%" height={350}>

--- a/frontend/src/components/projects-table/columns.spec.tsx
+++ b/frontend/src/components/projects-table/columns.spec.tsx
@@ -45,13 +45,25 @@ describe("columns", () => {
             description: "has description",
             isFavorite: true,
             status: "Done" as const,
-            taskSummary: { total: 4, completed: 4 },
+            taskSummary: {
+              Backlog: 0,
+              Todo: 0,
+              "In Progress": 0,
+              Done: 4,
+              Canceled: 0,
+            },
           },
           {
             ...baseProject,
             id: "2",
             name: "Another Project",
-            taskSummary: { total: 0, completed: 0 },
+            taskSummary: {
+              Backlog: 0,
+              Todo: 0,
+              "In Progress": 0,
+              Done: 0,
+              Canceled: 0,
+            },
           },
         ]}
         columns={columns}

--- a/frontend/src/components/projects-table/columns.tsx
+++ b/frontend/src/components/projects-table/columns.tsx
@@ -8,7 +8,12 @@ import { ProjectActions } from "./project-actions";
 import { ProjectStatusCell } from "./status-cell";
 import { ProjectUpdatedCell } from "./updated-cell";
 
-type ProjectRow = APIRoutes["projects"]["get"]["response"]["200"][number];
+type ProjectStats =
+  APIRoutes["projects"]["stats"]["get"]["response"]["200"][number];
+
+type ProjectRow = APIRoutes["projects"]["get"]["response"]["200"][number] & {
+  taskSummary: Omit<ProjectStats, "id" | "name">;
+};
 
 const columnHelper = createColumnHelper<ProjectRow>();
 
@@ -48,19 +53,22 @@ export const columns = [
     cell: (info) => <ProjectStatusCell status={info.getValue()} />,
   }),
   columnHelper.accessor(
-    (row) =>
-      row.taskSummary.total === 0
-        ? 0
-        : row.taskSummary.completed / row.taskSummary.total,
+    (row) => {
+      const total = Object.values(row.taskSummary).reduce((a, b) => a + b, 0);
+
+      return total === 0 ? 0 : row.taskSummary.Done / total;
+    },
     {
       id: "progress",
       header: "Progress",
-      cell: (info) => (
-        <ProjectProgressCell
-          total={info.row.original.taskSummary.total}
-          completed={info.row.original.taskSummary.completed}
-        />
-      ),
+      cell: (info) => {
+        const { taskSummary } = info.row.original;
+        const total = Object.values(taskSummary).reduce((a, b) => a + b, 0);
+
+        return (
+          <ProjectProgressCell total={total} completed={taskSummary.Done} />
+        );
+      },
     },
   ),
   columnHelper.accessor("isFavorite", {

--- a/frontend/src/components/projects-table/project-actions.spec.tsx
+++ b/frontend/src/components/projects-table/project-actions.spec.tsx
@@ -32,15 +32,10 @@ describe("<ProjectActions />", () => {
       }),
     );
 
-    await render(
-      <ProjectActions
-        project={{ ...project, taskSummary: { total: 4, completed: 2 } }}
-      />,
-      {
-        path: "/(authenticated)/projects/",
-        initialEntries: ["/(authenticated)/projects/"],
-      },
-    );
+    await render(<ProjectActions project={project} />, {
+      path: "/(authenticated)/projects/",
+      initialEntries: ["/(authenticated)/projects/"],
+    });
 
     expect(
       screen.getByRole("button", {

--- a/frontend/src/routes/(authenticated)/projects.index.tsx
+++ b/frontend/src/routes/(authenticated)/projects.index.tsx
@@ -1,14 +1,32 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-
 import { projectsQueryOptions } from "@/api/query-projects";
+import { projectStatsQueryOptions } from "@/api/query-projects-stats";
 import { CreateProject } from "@/components/create-project";
 import { columns } from "@/components/projects-table/columns";
 import { RouteErrorComponent } from "@/components/shared/route-error";
 import { Table } from "@/components/shared/table";
 
+const EMPTY_SUMMARY = {
+  Backlog: 0,
+  Todo: 0,
+  "In Progress": 0,
+  Done: 0,
+  Canceled: 0,
+};
+
 function Projects() {
   const { data: projects } = useSuspenseQuery(projectsQueryOptions);
+  const { data: stats } = useSuspenseQuery(projectStatsQueryOptions);
+
+  const statsById = new Map(
+    stats.map(({ id, name: _name, ...counts }) => [id, counts]),
+  );
+
+  const rows = projects.map((project) => ({
+    ...project,
+    taskSummary: statsById.get(project.id) ?? EMPTY_SUMMARY,
+  }));
 
   return (
     <div className="flex flex-col gap-6">
@@ -16,14 +34,17 @@ function Projects() {
         <h1 className="font-semibold text-base-content text-xl">Projects</h1>
         <CreateProject />
       </div>
-      <Table data={projects} columns={columns} />
+      <Table data={rows} columns={columns} />
     </div>
   );
 }
 
 export const Route = createFileRoute("/(authenticated)/projects/")({
   loader: ({ context }) => {
-    return context.queryClient.ensureQueryData(projectsQueryOptions);
+    return Promise.all([
+      context.queryClient.ensureQueryData(projectsQueryOptions),
+      context.queryClient.ensureQueryData(projectStatsQueryOptions),
+    ]);
   },
   component: Projects,
   errorComponent: RouteErrorComponent,


### PR DESCRIPTION
## Context

The backend had a "weird situation": two endpoints computed the *same* per-project task rollup two different ways — `GET /projects` (SQL `count()` → `taskSummary: { total, completed }`) and `GET /projects/totals` (every task row pulled into memory and `.reduce()`d in JS → per-status breakdown). Overlapping numbers, two techniques, drift risk.

This reworks it so the rollup lives in **exactly one place**, the projects entity stays lean, and there's no opt-in/optional-shape ambiguity (every endpoint has one concrete type).

## Changes

**Backend** (`backend/src/routes/projects.ts`)
- `GET /projects` → lean projects list (entity only, no `taskSummary`)
- `GET /projects/stats` → `[{ id, name, Backlog, Todo, "In Progress", Done, Canceled }]`, computed with one SQL grouped conditional-`count()` (the correct version of the old JS-`reduce` `/totals`)

**Frontend**
- New `query-projects-stats.ts` (`projectStatsQueryOptions`, key `["projects","stats"]`)
- Projects table composes lean list + stats for its progress column; overview chart reads `/projects/stats` directly (single query)
- Create-task dropdown uses the lean list — no more over-fetch
- Cache sync: `create`/`delete-project` update both caches; `edit-project` updates lean cache + stats `name`
- Task mutations (`create`/`delete`/`edit-task`) invalidate `["projects","stats"]` so the progress bar and chart refresh live on task changes

## Verification

- `lint` ✅ · `format` ✅ · `typecheck` ✅ (both workspaces) · `test` ✅ (29 files, 58 tests)
