### PR TITLE
Refine frontend iconography

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,8 @@ All dialogs use Radix UI primitives — `@radix-ui/react-dialog` for non-destruc
 
 **Close button:** positioned `absolute top-2 right-2` with classes `dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm`. This exact order must be preserved.
 
+**Title icons:** dialog and alert-dialog titles may include one leading Lucide icon when it reinforces the modal's purpose. The icon is decorative (`aria-hidden="true"`). Do not repeat the same action icon in the submit button.
+
 **Dialog.Description** must always be present. When the dialog body already provides sufficient visual context (e.g. an empty-state alert), render the description with `sr-only` to satisfy Radix's accessibility requirement without duplicating visible text.
 
 **Action row:** always `flex justify-end gap-2`. Never use `dsy-modal-action` — it is not part of the pattern.
@@ -213,6 +215,9 @@ The single `<Toaster>` mount lives in `src/routes/__root.tsx`, styled to DaisyUI
 ## Accessibility
 
 - Every icon-only interactive element must have either an `aria-label` prop or an `<span className="sr-only">` sibling providing its accessible name.
+- Use icon-only controls when the icon plus surrounding context tells the action story: the context supplies the object and the icon supplies the verb or state. Page-header create buttons, row action triggers, and tightly grouped detail actions are good candidates.
+- Keep visible text when the icon is ambiguous, the action submits or confirms a form, the action is destructive confirmation, or the item is inside a menu. Pair icon-only controls outside the sidebar with a DaisyUI tooltip for sighted discovery.
+- When visible text already names the action, mark the accompanying icon `aria-hidden="true"` so it does not add noise to the accessible name.
 - Every alert — whether an error, an empty state, or an inline warning — must carry `role="alert"`.
 - `Dialog.Description` must be present on every dialog. Use `className="sr-only"` when the visible dialog content already describes the context adequately.
 - Tooltips on sidebar nav items double as the accessible name discovery path for sighted keyboard users.

--- a/frontend/src/components/add-task-to-project.tsx
+++ b/frontend/src/components/add-task-to-project.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { ListPlusIcon, XIcon } from "lucide-react";
+import { ListPlusIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import { Dialog } from "radix-ui";
 import { useState } from "react";
 
@@ -44,9 +44,12 @@ export const AddTaskToProject = ({ projectId }: { projectId: string }) => {
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Trigger asChild>
-        <button type="button" className="dsy-btn dsy-btn-primary dsy-btn-sm">
-          <span className="hidden sm:inline">Add Task</span>
-          <ListPlusIcon className="h-4 w-4" />
+        <button
+          type="button"
+          className="dsy-btn dsy-btn-primary dsy-btn-square dsy-btn-sm"
+        >
+          <span className="sr-only">Add Task</span>
+          <ListPlusIcon aria-hidden="true" className="h-4 w-4" />
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>
@@ -60,10 +63,11 @@ export const AddTaskToProject = ({ projectId }: { projectId: string }) => {
                   className="dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm absolute top-2 right-2"
                   aria-label="Close"
                 >
-                  <XIcon className="h-4 w-4" />
+                  <XIcon aria-hidden="true" className="h-4 w-4" />
                 </button>
               </Dialog.Close>
-              <Dialog.Title className="font-bold text-lg">
+              <Dialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                <ListPlusIcon aria-hidden="true" className="h-4 w-4" />
                 Add Task
               </Dialog.Title>
               <Dialog.Description className="py-4 text-base-content/60 text-sm">
@@ -104,6 +108,7 @@ export const AddTaskToProject = ({ projectId }: { projectId: string }) => {
                     role="alert"
                     className="dsy-alert dsy-alert-error dsy-alert-soft"
                   >
+                    <TriangleAlertIcon aria-hidden="true" className="h-4 w-4" />
                     <span>{mutationError}</span>
                   </div>
                 )}
@@ -120,7 +125,7 @@ export const AddTaskToProject = ({ projectId }: { projectId: string }) => {
                     className="dsy-btn dsy-btn-primary dsy-btn-sm"
                     disabled={isPending}
                   >
-                    Add Task <ListPlusIcon className="h-4 w-4" />
+                    Add Task
                   </button>
                 </div>
               </form>

--- a/frontend/src/components/create-project.tsx
+++ b/frontend/src/components/create-project.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { FolderPlusIcon, XIcon } from "lucide-react";
+import { FolderPlusIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import { Dialog } from "radix-ui";
 import { useState } from "react";
 
@@ -37,12 +37,17 @@ export const CreateProject = () => {
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
-      <Dialog.Trigger asChild>
-        <button type="button" className="dsy-btn dsy-btn-primary dsy-btn-sm">
-          <span className="hidden sm:inline">Create Project</span>
-          <FolderPlusIcon className="h-4 w-4" />
-        </button>
-      </Dialog.Trigger>
+      <div className="dsy-tooltip dsy-tooltip-bottom" data-tip="Create project">
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            className="dsy-btn dsy-btn-primary dsy-btn-square dsy-btn-sm"
+          >
+            <span className="sr-only">Create Project</span>
+            <FolderPlusIcon aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </Dialog.Trigger>
+      </div>
       <Dialog.Portal>
         <Dialog.Overlay />
         <Dialog.Content asChild>
@@ -54,10 +59,11 @@ export const CreateProject = () => {
                   className="dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm absolute top-2 right-2"
                   aria-label="Close"
                 >
-                  <XIcon className="h-4 w-4" />
+                  <XIcon aria-hidden="true" className="h-4 w-4" />
                 </button>
               </Dialog.Close>
-              <Dialog.Title className="font-bold text-lg">
+              <Dialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                <FolderPlusIcon aria-hidden="true" className="h-4 w-4" />
                 Create Project
               </Dialog.Title>
               <Dialog.Description className="py-4 text-base-content/60 text-sm">
@@ -75,6 +81,7 @@ export const CreateProject = () => {
                     role="alert"
                     className="dsy-alert dsy-alert-error dsy-alert-soft"
                   >
+                    <TriangleAlertIcon aria-hidden="true" className="h-4 w-4" />
                     <span>{mutationError}</span>
                   </div>
                 )}
@@ -91,7 +98,7 @@ export const CreateProject = () => {
                     className="dsy-btn dsy-btn-primary dsy-btn-sm"
                     disabled={isPending}
                   >
-                    Create Project <FolderPlusIcon className="h-4 w-4" />
+                    Create Project
                   </button>
                 </div>
               </form>

--- a/frontend/src/components/create-task.tsx
+++ b/frontend/src/components/create-task.tsx
@@ -1,6 +1,11 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { getRouteApi, Link } from "@tanstack/react-router";
-import { ListPlusIcon, XIcon } from "lucide-react";
+import {
+  FolderPlusIcon,
+  ListPlusIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-react";
 import { Dialog } from "radix-ui";
 import { useState } from "react";
 
@@ -49,12 +54,17 @@ export const CreateTask = () => {
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
-      <Dialog.Trigger asChild>
-        <button type="button" className="dsy-btn dsy-btn-primary dsy-btn-sm">
-          <span className="hidden sm:inline">Create Task</span>
-          <ListPlusIcon className="h-4 w-4" />
-        </button>
-      </Dialog.Trigger>
+      <div className="dsy-tooltip dsy-tooltip-bottom" data-tip="Create task">
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            className="dsy-btn dsy-btn-primary dsy-btn-square dsy-btn-sm"
+          >
+            <span className="sr-only">Create Task</span>
+            <ListPlusIcon aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </Dialog.Trigger>
+      </div>
       <Dialog.Portal>
         <Dialog.Overlay />
         <Dialog.Content asChild>
@@ -66,10 +76,11 @@ export const CreateTask = () => {
                   className="dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm absolute top-2 right-2"
                   aria-label="Close"
                 >
-                  <XIcon className="h-4 w-4" />
+                  <XIcon aria-hidden="true" className="h-4 w-4" />
                 </button>
               </Dialog.Close>
-              <Dialog.Title className="font-bold text-lg">
+              <Dialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                <ListPlusIcon aria-hidden="true" className="h-4 w-4" />
                 Create Task
               </Dialog.Title>
               {projects.length === 0 ? (
@@ -78,6 +89,7 @@ export const CreateTask = () => {
                     No projects available. Create a project to add tasks.
                   </Dialog.Description>
                   <div role="alert" className="dsy-alert dsy-alert-soft mt-4">
+                    <FolderPlusIcon aria-hidden="true" className="h-4 w-4" />
                     <span>
                       You need a project before creating a task.{" "}
                       <Link
@@ -152,6 +164,10 @@ export const CreateTask = () => {
                         role="alert"
                         className="dsy-alert dsy-alert-error dsy-alert-soft"
                       >
+                        <TriangleAlertIcon
+                          aria-hidden="true"
+                          className="h-4 w-4"
+                        />
                         <span>{mutationError}</span>
                       </div>
                     )}
@@ -168,7 +184,7 @@ export const CreateTask = () => {
                         className="dsy-btn dsy-btn-primary dsy-btn-sm"
                         disabled={isPending}
                       >
-                        New Task <ListPlusIcon className="h-4 w-4" />
+                        New Task
                       </button>
                     </div>
                   </form>

--- a/frontend/src/components/delete-project.tsx
+++ b/frontend/src/components/delete-project.tsx
@@ -43,7 +43,7 @@ export const DeleteProject = ({
             <span className={cn(hideText ? "sr-only" : "hidden sm:inline")}>
               Delete{" "}
             </span>
-            <FolderMinusIcon className="h-4 w-4" />
+            <FolderMinusIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </AlertDialog.Trigger>
       )}
@@ -65,7 +65,8 @@ export const DeleteProject = ({
                   });
                 }}
               >
-                <AlertDialog.Title className="font-bold text-lg">
+                <AlertDialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                  <FolderMinusIcon aria-hidden="true" className="h-4 w-4" />
                   Are You Sure?
                 </AlertDialog.Title>
                 <AlertDialog.Description className="py-4 text-base-content/60 text-sm">

--- a/frontend/src/components/edit-project.tsx
+++ b/frontend/src/components/edit-project.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { FolderPenIcon, SaveIcon, XIcon } from "lucide-react";
+import { FolderPenIcon, XIcon } from "lucide-react";
 import { Dialog } from "radix-ui";
 import { useState } from "react";
 
@@ -46,7 +46,7 @@ export const EditProject = ({
             <span className={cn(hideText ? "sr-only" : "hidden sm:inline")}>
               Edit{" "}
             </span>
-            <FolderPenIcon className="h-4 w-4" />
+            <FolderPenIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </Dialog.Trigger>
       )}
@@ -61,10 +61,11 @@ export const EditProject = ({
                   className="dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm absolute top-2 right-2"
                   aria-label="Close"
                 >
-                  <XIcon className="h-4 w-4" />
+                  <XIcon aria-hidden="true" className="h-4 w-4" />
                 </button>
               </Dialog.Close>
-              <Dialog.Title className="font-bold text-lg">
+              <Dialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                <FolderPenIcon aria-hidden="true" className="h-4 w-4" />
                 Edit Project
               </Dialog.Title>
               <Dialog.Description className="py-4 text-base-content/60 text-sm">
@@ -118,7 +119,7 @@ export const EditProject = ({
                     type="submit"
                     className="dsy-btn dsy-btn-neutral dsy-btn-sm"
                   >
-                    Save <SaveIcon className="h-4 w-4" />
+                    Save
                   </button>
                 </div>
               </form>

--- a/frontend/src/components/error-status.tsx
+++ b/frontend/src/components/error-status.tsx
@@ -1,4 +1,5 @@
 import { type ErrorComponentProps, Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, TriangleAlertIcon } from "lucide-react";
 
 export const ErrorStatus = ({ error }: ErrorComponentProps) => {
   return (
@@ -9,8 +10,12 @@ export const ErrorStatus = ({ error }: ErrorComponentProps) => {
             <h1 className="mb-5 font-bold text-5xl lg:text-7xl xl:text-9xl">
               Error
             </h1>
-            <p className="mb-5 text-error">{error.message}</p>
+            <p className="mb-5 inline-flex items-center gap-2 text-error">
+              <TriangleAlertIcon aria-hidden="true" className="h-4 w-4" />
+              <span>{error.message}</span>
+            </p>
             <Link className="dsy-btn dsy-btn-outline" to="/">
+              <ArrowLeftIcon aria-hidden="true" className="h-4 w-4" />
               Go back
             </Link>
           </div>

--- a/frontend/src/components/not-found.tsx
+++ b/frontend/src/components/not-found.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, SearchXIcon } from "lucide-react";
 
 export const NotFound = () => {
   return (
@@ -9,8 +10,12 @@ export const NotFound = () => {
             <h1 className="mb-5 font-bold text-5xl lg:text-7xl xl:text-9xl">
               Error
             </h1>
-            <p className="mb-5 text-error">Not Found</p>
+            <p className="mb-5 inline-flex items-center gap-2 text-error">
+              <SearchXIcon aria-hidden="true" className="h-4 w-4" />
+              <span>Not Found</span>
+            </p>
             <Link className="dsy-btn dsy-btn-outline" to="/">
+              <ArrowLeftIcon aria-hidden="true" className="h-4 w-4" />
               Go back
             </Link>
           </div>

--- a/frontend/src/components/project-details.spec.tsx
+++ b/frontend/src/components/project-details.spec.tsx
@@ -42,5 +42,10 @@ describe("<ProjectDetails />", () => {
     });
 
     expect(heading).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add Task" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project-details.tsx
+++ b/frontend/src/components/project-details.tsx
@@ -26,9 +26,26 @@ export const ProjectDetails = () => {
       </div>
 
       <div className="flex shrink-0 items-center gap-1">
-        <AddTaskToProject projectId={projectId} />
-        <EditProject projectId={projectId} />
-        <DeleteProject projectId={projectId} />
+        <div className="dsy-tooltip dsy-tooltip-bottom" data-tip="Add task">
+          <AddTaskToProject projectId={projectId} />
+        </div>
+        <div className="dsy-tooltip dsy-tooltip-bottom" data-tip="Edit project">
+          <EditProject
+            projectId={projectId}
+            hideText
+            className="dsy-btn dsy-btn-neutral dsy-btn-square dsy-btn-sm"
+          />
+        </div>
+        <div
+          className="dsy-tooltip dsy-tooltip-bottom"
+          data-tip="Delete project"
+        >
+          <DeleteProject
+            projectId={projectId}
+            hideText
+            className="dsy-btn dsy-btn-error dsy-btn-square dsy-btn-sm"
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/project-tasks-list.tsx
+++ b/frontend/src/components/project-tasks-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { ListPlusIcon } from "lucide-react";
 
 import type { APIRoutes } from "@/api/client";
 
@@ -14,6 +15,7 @@ export const ProjectTasksList = ({ tasks }: ProjectTasksListProps) => {
   if (tasks.length === 0) {
     return (
       <div role="alert" className="dsy-alert dsy-alert-soft">
+        <ListPlusIcon aria-hidden="true" className="h-4 w-4" />
         <span>No tasks for this project yet.</span>
       </div>
     );

--- a/frontend/src/components/shared/route-error.tsx
+++ b/frontend/src/components/shared/route-error.tsx
@@ -1,4 +1,5 @@
 import type { ErrorComponentProps } from "@tanstack/react-router";
+import { TriangleAlertIcon } from "lucide-react";
 
 export const RouteErrorComponent = ({ error }: ErrorComponentProps) => {
   const message =
@@ -6,6 +7,7 @@ export const RouteErrorComponent = ({ error }: ErrorComponentProps) => {
 
   return (
     <div role="alert" className="dsy-alert dsy-alert-error dsy-alert-soft">
+      <TriangleAlertIcon aria-hidden="true" className="h-4 w-4" />
       <span>{message}</span>
     </div>
   );

--- a/frontend/src/components/shared/table.spec.tsx
+++ b/frontend/src/components/shared/table.spec.tsx
@@ -31,6 +31,20 @@ describe("<Table />", () => {
     }
   });
 
+  it("should expose unsorted state on sortable column headers", async () => {
+    await render(
+      <Table
+        data={[{ id: 1, name: "apple", color: "red" }]}
+        columns={columns}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "name" })).toHaveAttribute(
+      "aria-sort",
+      "none",
+    );
+  });
+
   it("should not render a global filter input", async () => {
     await render(
       <Table

--- a/frontend/src/components/shared/table.tsx
+++ b/frontend/src/components/shared/table.tsx
@@ -9,6 +9,7 @@ import {
   ArrowDownWideNarrowIcon,
   ArrowUpWideNarrowIcon,
   CheckIcon,
+  SearchXIcon,
   XIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -57,12 +58,21 @@ export function Table<TData, TColumns extends ColumnDef<TData, any>[]>({
                 return (
                   <th
                     key={header.id}
+                    aria-sort={
+                      header.column.getCanSort()
+                        ? sort === "asc"
+                          ? "ascending"
+                          : sort === "desc"
+                            ? "descending"
+                            : "none"
+                        : undefined
+                    }
                     className="text-base-content/50 text-xs uppercase tracking-wider"
                   >
                     {header.isPlaceholder ? null : header.column.getCanSort() ? (
                       <button
                         type="button"
-                        className="uppercase"
+                        className="inline-flex items-center uppercase"
                         onClick={header.column.getToggleSortingHandler()}
                       >
                         {flexRender(
@@ -70,9 +80,15 @@ export function Table<TData, TColumns extends ColumnDef<TData, any>[]>({
                           header.getContext(),
                         )}
                         {sort === false ? null : sort === "asc" ? (
-                          <ArrowUpWideNarrowIcon className="ml-1 inline h-3.5 w-3.5" />
+                          <ArrowUpWideNarrowIcon
+                            aria-hidden="true"
+                            className="ml-1 inline h-3.5 w-3.5"
+                          />
                         ) : (
-                          <ArrowDownWideNarrowIcon className="ml-1 inline h-3.5 w-3.5" />
+                          <ArrowDownWideNarrowIcon
+                            aria-hidden="true"
+                            className="ml-1 inline h-3.5 w-3.5"
+                          />
                         )}
                       </button>
                     ) : (
@@ -92,6 +108,7 @@ export function Table<TData, TColumns extends ColumnDef<TData, any>[]>({
             <tr>
               <td colSpan={table.getVisibleLeafColumns().length}>
                 <div role="alert" className="dsy-alert dsy-alert-soft">
+                  <SearchXIcon aria-hidden="true" className="h-4 w-4" />
                   <span>No results.</span>
                 </div>
               </td>

--- a/frontend/src/components/tasks-table/delete-task-dialog.tsx
+++ b/frontend/src/components/tasks-table/delete-task-dialog.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { TrashIcon } from "lucide-react";
 import { AlertDialog } from "radix-ui";
 
 import { deleteTaskMutationOptions } from "@/api/delete-task";
@@ -33,7 +34,8 @@ export const DeleteTaskDialog = ({
                   });
                 }}
               >
-                <AlertDialog.Title className="font-bold text-lg">
+                <AlertDialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                  <TrashIcon aria-hidden="true" className="h-4 w-4" />
                   Are You Sure?
                 </AlertDialog.Title>
                 <AlertDialog.Description className="py-4 text-base-content/60 text-sm">

--- a/frontend/src/components/tasks-table/rename-task-dialog.tsx
+++ b/frontend/src/components/tasks-table/rename-task-dialog.tsx
@@ -35,11 +35,12 @@ export const RenameTaskDialog = ({
                   className="dsy-btn dsy-btn-ghost dsy-btn-circle dsy-btn-sm absolute top-2 right-2"
                   aria-label="Close"
                 >
-                  <XIcon className="h-4 w-4" />
+                  <XIcon aria-hidden="true" className="h-4 w-4" />
                 </button>
               </Dialog.Close>
 
-              <Dialog.Title className="font-bold text-lg">
+              <Dialog.Title className="inline-flex items-center gap-2 font-bold text-lg">
+                <SaveIcon aria-hidden="true" className="h-4 w-4" />
                 Rename The Task
               </Dialog.Title>
 
@@ -68,7 +69,6 @@ export const RenameTaskDialog = ({
                     type="submit"
                     className="dsy-btn dsy-btn-neutral dsy-btn-sm"
                   >
-                    <SaveIcon className="h-4 w-4" />
                     Save
                   </button>
                 </div>

--- a/frontend/src/routes/(auth)/login.tsx
+++ b/frontend/src/routes/(auth)/login.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
+import { LogInIcon } from "lucide-react";
 import * as v from "valibot";
 
 import { meQueryOptions } from "@/api/query-me";
@@ -59,6 +60,7 @@ function Login() {
 
           <button type="submit" className="dsy-btn dsy-btn-primary w-full">
             Sign in
+            <LogInIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </form>
 

--- a/frontend/src/routes/(auth)/signup.tsx
+++ b/frontend/src/routes/(auth)/signup.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
+import { UserPlusIcon } from "lucide-react";
 
 import { PasswordInput } from "@/components/password-input";
 import { RouteErrorComponent } from "@/components/shared/route-error";
@@ -56,6 +57,7 @@ function SignUp() {
 
           <button type="submit" className="dsy-btn dsy-btn-primary w-full">
             Sign up
+            <UserPlusIcon aria-hidden="true" className="h-4 w-4" />
           </button>
         </form>
 

--- a/frontend/src/routes/(authenticated)/route.tsx
+++ b/frontend/src/routes/(authenticated)/route.tsx
@@ -80,7 +80,12 @@ function Component() {
               target="_blank"
               rel="noreferrer"
             >
-              <Icon icon="simple-icons:github" className="h-3.5 w-3.5" />
+              <Icon
+                icon="simple-icons:github"
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+              />
+              <span className="sr-only">GitHub</span>
             </a>
           </div>
           <div className="dsy-tooltip dsy-tooltip-right" data-tip="API Docs">
@@ -90,7 +95,12 @@ function Component() {
               target="_blank"
               rel="noreferrer"
             >
-              <Icon icon="simple-icons:scalar" className="h-3.5 w-3.5" />
+              <Icon
+                icon="simple-icons:scalar"
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+              />
+              <span className="sr-only">API Docs</span>
             </a>
           </div>
           <div className="dsy-tooltip dsy-tooltip-right" data-tip="Telemetry">
@@ -100,7 +110,12 @@ function Component() {
               target="_blank"
               rel="noreferrer"
             >
-              <Icon icon="simple-icons:opentelemetry" className="h-3.5 w-3.5" />
+              <Icon
+                icon="simple-icons:opentelemetry"
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+              />
+              <span className="sr-only">Telemetry</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
## What
- Use icon-first controls where page or detail context makes the action clear.
- Add accessible names, tooltips, and decorative icon handling for icon-only controls.
- Keep dialog actions text-forward while using icons for titles and stateful alerts.

## Why
- Improves scanability and visual storytelling without sacrificing accessibility or making dialogs noisy.